### PR TITLE
chore(gh-actions): fixed access token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@1.16
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_DOMAIN: cli.sasjs.io


### PR DESCRIPTION
## Intent

- Use `GITHUB_TOKEN` as an access token in github actions.

## Implementation

- Updated `.github/workflows/publish.yml`.