### PR TITLE
docs(verbose): updated job and env docs

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -34,3 +34,4 @@ Verbose mode will also be enabled if `LOG_LEVEL` is set to `Trace` (case insensi
 
 !!! note
     Verbose mode can also be enabled for a single `sasjs job execute` command by adding the `--verbose`(`-v`) flag.
+    To enable bleached verbose mode, add `bleached` after `-v` flag (eg `sasjs job execute -v bleached`).

--- a/docs/env.md
+++ b/docs/env.md
@@ -28,7 +28,7 @@ Created when running `sasjs auth` against a Viya target.  The CLI will use this 
 
 Verbose mode will log a summary of every HTTP request/response to the console - this is helpful in troubleshooting edge cases and unusual server responses.
 
-`VERBOSE=ON` (case insensitive) will enable the debug mode. Everything else (eg `VERBOSE=OFF`) will disable it.  The option is disabled by default.
+`VERBOSE=ON` (case insensitive) will enable the debug mode. To remove extra colors from logged message, set `VERBOSE=BLEACHED` (case insensitive). Everything else (eg `VERBOSE=OFF`) will disable it.  The option is disabled by default.
 
 Verbose mode will also be enabled if `LOG_LEVEL` is set to `Trace` (case insensitive) in the `.env*` file.
 

--- a/docs/job.md
+++ b/docs/job.md
@@ -31,7 +31,7 @@ Additional arguments may include:
 - `--output` (alias `-o`) - path where output of the finished job execution will be saved.
 - `--source` (alieas `-s`) - Provide the path to an input JSON containing job variables, structured as follows:  `{"macroVars":{"varname":"value","var2":"val2"}}`
 - `--target` (alias `-t`) - the target environment in which to deploy the services. If not specified, default target will be used, mentioned in `sasjsconfig.json`. The target can exist either in the local project configuration or in the global `.sasjsrc` file.
-- `--verbose` (alias `-v`) - if present, CLI will log summary of every HTTP request/response. If set to 'bleached', CLI will log summary of every HTTP response without extra colors.
+- `--verbose` (alias `-v`) - if present, CLI will log summary of every HTTP request/response. If set to 'bleached' (eg `-v bleached`), CLI will log summary of every HTTP response without extra colors.
 
 The following flags are only relevant for serverType VIYA:
 

--- a/docs/job.md
+++ b/docs/job.md
@@ -31,7 +31,7 @@ Additional arguments may include:
 - `--output` (alias `-o`) - path where output of the finished job execution will be saved.
 - `--source` (alieas `-s`) - Provide the path to an input JSON containing job variables, structured as follows:  `{"macroVars":{"varname":"value","var2":"val2"}}`
 - `--target` (alias `-t`) - the target environment in which to deploy the services. If not specified, default target will be used, mentioned in `sasjsconfig.json`. The target can exist either in the local project configuration or in the global `.sasjsrc` file.
-- `--verbose` (alias `-v`) - if present, CLI will log summary of every HTTP request/response.
+- `--verbose` (alias `-v`) - if present, CLI will log summary of every HTTP request/response. If set to 'bleached', CLI will log summary of every HTTP response without extra colors.
 
 The following flags are only relevant for serverType VIYA:
 


### PR DESCRIPTION
## Intent

- Document Bleached Verbose Mode that can be enabled through an environment variable or `sasjs job execute` command in `@sasjs/cli`.

## Implementation

- Updated `docs/env.md`.
- Updated `docs/job.md`.
